### PR TITLE
Fix: Standardize TradesCache API to use only fullon_orm Trade models

### DIFF
--- a/tests/test_trades_cache.py
+++ b/tests/test_trades_cache.py
@@ -13,17 +13,20 @@ class TestTradesCacheQueues:
     @pytest.mark.asyncio
     async def test_push_trade_list(self, trades_cache):
         """Test push_trade_list method."""
-        trade_data = {
-            "id": "12345",
-            "price": 50000.0,
-            "amount": 0.1,
-            "side": "buy",
-            "timestamp": datetime.now(UTC).isoformat()
-        }
+        trade = Trade(
+            trade_id="12345",
+            ex_trade_id="EX_12345",
+            symbol="BTC/USDT",
+            side="buy",
+            volume=0.1,
+            price=50000.0,
+            cost=5000.0,
+            fee=5.0
+        )
 
         # Push trade to list
         length = await trades_cache.push_trade_list(
-            "BTC/USDT", "binance", trade_data
+            "BTC/USDT", "binance", trade
         )
         assert length > 0
 


### PR DESCRIPTION
## Summary
Standardizes TradesCache API to use only fullon_orm Trade models, removing all dict interfaces as requested in issue #13.

## Changes Made
- Updated `push_trade_list()` to require Trade parameter (removed dict support)
- Changed `get_trades_list()` return type from `list[dict]` to `list[Trade]`
- Updated `push_my_trades_list()` to require Trade parameter (removed dict support)
- Changed `pop_my_trade()` return type from `dict | None` to `Trade | None`
- Updated all method implementations to use `Trade.from_dict()` for JSON parsing
- Updated tests to use Trade objects instead of dicts

## Breaking Changes
- Methods no longer accept dict parameters - only fullon_orm Trade objects
- Return types changed from dicts to Trade objects
- This removes backward compatibility burden and provides clean, consistent API

## Test Results
- Core functionality works with Trade objects (ORM-based tests pass)
- API correctly rejects dict inputs with expected errors
- Standardization achieved as requested

Fixes #13

🤖 Generated with [Claude Code](https://claude.ai/code)