### PR TITLE
Standardize OrdersCache API to use only fullon_orm Order models

### DIFF
--- a/tests/test_integration_performance.py
+++ b/tests/test_integration_performance.py
@@ -279,17 +279,15 @@ class TestOrderPerformance:
         cache = orders_cache
         
         try:
-            # Create test order
-            order = create_test_order("BTC/USDT", "buy", 0.1, "PERF_ORDER")
-            order_data = order.to_dict()
-            
             # Benchmark save operations
             save_times = []
             for i in range(50):
                 order_id = f"SAVE_ORD_{i}"
+                # Create test order with unique ID
+                order = create_test_order("BTC/USDT", "buy", 0.1, order_id)
                 
                 start = time.perf_counter()
-                await cache.save_order_data("binance", order_id, order_data)
+                await cache.save_order_data("binance", order)
                 end = time.perf_counter()
                 
                 save_times.append((end - start) * 1000)
@@ -402,7 +400,7 @@ class TestConcurrentPerformance:
                     order = create_test_order("MIX/USDT", "buy", 0.1, f"MIX_ORD_{i}")
                     
                     start = time.perf_counter()
-                    await orders_cache.save_order_data("binance", order.ex_order_id, order.to_dict())
+                    await orders_cache.save_order_data("binance", order)
                     end = time.perf_counter()
                     
                     times.append((end - start) * 1000)

--- a/tests/test_orders_cache_coverage.py
+++ b/tests/test_orders_cache_coverage.py
@@ -1,10 +1,36 @@
 """Additional tests to achieve 100% coverage for OrdersCache."""
 
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from fullon_orm.models import Order
 from redis.exceptions import RedisError
+
+
+def create_test_order(symbol="BTC/USDT", side="buy", volume=0.1, order_id="ORD_001", exchange="binance", **kwargs):
+    """Factory for test Order objects."""
+    return Order(
+        ex_order_id=order_id,
+        ex_id=exchange,
+        symbol=symbol,
+        side=side,
+        order_type=kwargs.get("order_type", "market"),
+        volume=volume,
+        price=kwargs.get("price", 50000.0),
+        uid=kwargs.get("uid", "user_123"),
+        status=kwargs.get("status", "open"),
+        bot_id=kwargs.get("bot_id", 123),
+        cat_ex_id=kwargs.get("cat_ex_id", 1),
+        final_volume=kwargs.get("final_volume"),
+        plimit=kwargs.get("plimit"),
+        tick=kwargs.get("tick"),
+        futures=kwargs.get("futures"),
+        leverage=kwargs.get("leverage"),
+        command=kwargs.get("command"),
+        reason=kwargs.get("reason"),
+        timestamp=kwargs.get("timestamp", datetime.now(UTC))
+    )
 
 
 class TestOrdersCacheCoverage:
@@ -36,13 +62,15 @@ class TestOrdersCacheCoverage:
     @pytest.mark.asyncio
     async def test_save_order_data_with_cancelled_status(self, orders_cache):
         """Test save_order_data sets expiry for cancelled orders."""
-        order_data = {
-            "status": "cancelled",
-            "symbol": "BTC/USDT"
-        }
+        cancelled_order = create_test_order(
+            status="cancelled",
+            symbol="BTC/USDT",
+            order_id="order123",
+            exchange="binance"
+        )
 
         # Should set expiry without error
-        await orders_cache.save_order_data("binance", "order123", order_data)
+        await orders_cache.save_order_data("binance", cancelled_order)
 
     @pytest.mark.asyncio
     async def test_get_order_status_attribute_error(self, orders_cache):


### PR DESCRIPTION
## Summary
Fixes #14 by standardizing the OrdersCache API to use only fullon_orm Order models, removing the dict-based interface from the `save_order_data` method.

- **API Change**: `save_order_data(ex_id: str, oid: str, data: dict)` → `save_order_data(ex_id: str, order: Order)`
- **Extract order ID** from `order.ex_order_id` or `order.order_id`
- **Use Order.to_dict()** internally for Redis storage
- **Maintain all existing functionality** (TTL for cancelled orders, data merging, etc.)

## Changes Made
- ✅ Updated `save_order_data` method signature to accept Order model instead of dict
- ✅ Updated all test files to use Order models following TDD principles
- ✅ Enhanced test factory functions to support flexible Order creation
- ✅ All OrdersCache tests passing (27/27)
- ✅ Maintains backward compatibility in functionality while removing dict API

## API Migration Examples

**Before:**
```python
await orders_cache.save_order_data("binance", "ORD123", {
    "symbol": "BTC/USDT", 
    "side": "buy",
    "volume": 0.1
})
```

**After:**
```python
order = Order(
    ex_order_id="ORD123",
    symbol="BTC/USDT",
    side="buy", 
    volume=0.1,
    exchange="binance",
    timestamp=datetime.now(UTC)
)
await orders_cache.save_order_data("binance", order)
```

## Test Status
- ✅ All OrdersCache core tests pass
- ✅ All OrdersCache coverage tests pass  
- ✅ TDD approach followed (tests updated first, then implementation)
- ✅ No regressions in existing functionality

## Benefits
- **Type Safety**: No more dict/Order ambiguity 
- **API Consistency**: All methods now use fullon_orm Order models
- **Simplified Logic**: Remove manual dict merging, use Order model methods
- **Better Developer Experience**: Clear, predictable method signatures
- **Maintainability**: Single code path, no branching logic for data types

🤖 Generated with [Claude Code](https://claude.ai/code)